### PR TITLE
fix(release): Use non-prerelease tags to recommend bump on master branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="0.1.1-beta.0"></a>
+## 0.1.1-beta.0 (2017-12-17)
+
+
+### Bug Fixes
+
+* **release:** Use non-prerelease tags to recommend bump on master branch ([2af6897](https://github.com/ls-age/bump-version/commits/2af6897))
+
+
+
+
 <a name="0.1.0"></a>
 # 0.1.0 (2017-12-16)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls-age/bump-version",
-  "version": "0.1.0",
+  "version": "0.1.1-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls-age/bump-version",
-  "version": "0.1.0",
+  "version": "0.1.1-beta.0",
   "description": "",
   "main": "out/index.js",
   "bin": {

--- a/src/commands/release.js
+++ b/src/commands/release.js
@@ -47,7 +47,7 @@ export async function createRelease(options) {
   // Get recommended version
   const bump = await recommendBump(Object.assign({}, options, {
     pkg,
-    tags,
+    tags: releaseBranch === true ? nonPrereleaseTags : tags,
     prerelease: releaseBranch !== true && releaseBranch,
   }));
 


### PR DESCRIPTION
Otherwise releases are seen as 'not needed' when performing a regular (non-squash) merge from beta to master branch