### PR TITLE
fix(recommend-bump): Prevent error on initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="0.1.4-beta.0"></a>
+## 0.1.4-beta.0 (2018-03-16)
+
+
+### Bug Fixes
+
+* **recommend-bump:** Prevent error on initial release ([adc3f3c](https://github.com/ls-age/bump-version/commits/adc3f3c))
+
+
+
+
 <a name="0.1.3"></a>
 ## 0.1.3 (2018-02-20)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls-age/bump-version",
-  "version": "0.1.3",
+  "version": "0.1.4-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ls-age/bump-version",
-  "version": "0.1.3",
+  "version": "0.1.4-beta.0",
   "description": "Automated npm and GitHub releases based on commit messages",
   "main": "out/index.js",
   "bin": {

--- a/src/commands/recommend-bump.js
+++ b/src/commands/recommend-bump.js
@@ -51,8 +51,8 @@ export async function recommendBump(options) {
   const levelIfNeeded = Math.min(level, 2);
   let incType = `${options.prerelease ? 'pre' : ''}${VersionTypes[levelIfNeeded]}`;
 
-  const lastIsPrerelease = isPrerelease(latestTag.name);
-  const alreadyAhead = lt(latestTag.name, pkg.version);
+  const lastIsPrerelease = latestTag && isPrerelease(latestTag.name);
+  const alreadyAhead = latestTag && lt(latestTag.name, pkg.version);
 
   if (options.prerelease && latestTag && (lastIsPrerelease || alreadyAhead)) {
     const versionToCheck = alreadyAhead ? pkg.version : latestTag.name;


### PR DESCRIPTION
Fixes an error that occures when an initial release is created and the initial release is prerelease